### PR TITLE
Fix blank page on initial loads sometimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "kaddex-ui",
   "version": "0.1.0",
   "private": true,
-  "homepage": "./",
   "dependencies": {
     "@sweetalert/with-react": "^0.1.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/post-build.js
+++ b/post-build.js
@@ -15,7 +15,7 @@ const parts = builtHTMLContent.split(splitBy);
 const fileWithPreload = [parts[0], splitBy];
 
 for (const link of assets) {
-  fileWithPreload.push(`<link rel="preload" href="./${link}" as="font" crossorigin="anonymous">`);
+  fileWithPreload.push(`<link rel="preload" href="/${link}" as="font" crossorigin="anonymous">`);
 }
 
 fileWithPreload.push(parts[1]);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "eckoDEX",
   "icons": [
     {
-      "src": "./images/maskable_icon.png",
+      "src": "/images/maskable_icon.png",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/svg",
       "purpose": "maskable"
@@ -14,7 +14,7 @@
       "type": "image/svg"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#240B2F"


### PR DESCRIPTION
This fixes loading URLs like `/liquidity/tokens` on first load (since it would try to load images and scripts from starting from `/liquidity` rather than `/`). Unfortunately, adding `"homepage": "./"` to `package.json` breaks client-side routing in React.