### PR TITLE
fix for account name incorrect format supporting KIP-17

### DIFF
--- a/src/components/modals/kdaModals/ConnectWalletWalletConnectModal.js
+++ b/src/components/modals/kdaModals/ConnectWalletWalletConnectModal.js
@@ -4,7 +4,7 @@ import Label from '../../shared/Label';
 import { NETWORKID } from '../../../constants/contextConstants';
 import { useAccountContext, useGameEditionContext, useModalContext, useWalletConnectContext } from '../../../contexts';
 import GetWalletConnectAccountModal from './GetWalletConnectAccountModal';
-import { convertWalletConnectAccountName } from "../../../utils/string-utils";
+import { convertWalletConnectAccountName } from '../../../utils/string-utils';
 
 const ConnectWalletWalletConnectModal = ({ onConnectionSuccess }) => {
   const modalContext = useModalContext();

--- a/src/components/modals/kdaModals/ConnectWalletWalletConnectModal.js
+++ b/src/components/modals/kdaModals/ConnectWalletWalletConnectModal.js
@@ -4,6 +4,7 @@ import Label from '../../shared/Label';
 import { NETWORKID } from '../../../constants/contextConstants';
 import { useAccountContext, useGameEditionContext, useModalContext, useWalletConnectContext } from '../../../contexts';
 import GetWalletConnectAccountModal from './GetWalletConnectAccountModal';
+import { convertWalletConnectAccountName } from "../../../utils/string-utils";
 
 const ConnectWalletWalletConnectModal = ({ onConnectionSuccess }) => {
   const modalContext = useModalContext();
@@ -33,7 +34,7 @@ const ConnectWalletWalletConnectModal = ({ onConnectionSuccess }) => {
           wcAccounts.accounts.forEach((wcAcc) => wcAcc.kadenaAccounts.forEach((kAcc) => resultAccounts.push(kAcc.name)));
 
           if (resultAccounts.length === 1) {
-            await setVerifiedAccount(resultAccounts[0], onConnectionSuccess);
+            await setVerifiedAccount(convertWalletConnectAccountName(resultAccounts[0]), onConnectionSuccess);
             modalContext.closeModal();
           } else {
             if (gameEditionView) {

--- a/src/components/modals/kdaModals/GetWalletConnectAccountModal.js
+++ b/src/components/modals/kdaModals/GetWalletConnectAccountModal.js
@@ -8,7 +8,7 @@ import Label from '../../shared/Label';
 import { GeArrowIcon } from '../../../assets';
 import { useAccountContext, useGameEditionContext, useModalContext, useWalletContext } from '../../../contexts';
 import { WALLET } from '../../../constants/wallet';
-import { convertWalletConnectAccountName } from "../../../utils/string-utils";
+import { convertWalletConnectAccountName } from '../../../utils/string-utils';
 
 const ActionContainer = styled.div`
   display: flex;

--- a/src/components/modals/kdaModals/GetWalletConnectAccountModal.js
+++ b/src/components/modals/kdaModals/GetWalletConnectAccountModal.js
@@ -8,6 +8,7 @@ import Label from '../../shared/Label';
 import { GeArrowIcon } from '../../../assets';
 import { useAccountContext, useGameEditionContext, useModalContext, useWalletContext } from '../../../contexts';
 import { WALLET } from '../../../constants/wallet';
+import { convertWalletConnectAccountName } from "../../../utils/string-utils";
 
 const ActionContainer = styled.div`
   display: flex;
@@ -114,9 +115,9 @@ const GetWalletConnectAccountModal = ({ accounts: accountsProps, onClose, onConn
   }, [onClose]);
 
   const handleConnect = useCallback(async () => {
-    await setVerifiedAccount(selectedAccount, onConnectionSuccess);
+    await setVerifiedAccount(convertWalletConnectAccountName(selectedAccount), onConnectionSuccess);
     setTimeout(async () => {
-      await setVerifiedAccount(selectedAccount, onConnectionSuccess);
+      await setVerifiedAccount(convertWalletConnectAccountName(selectedAccount), onConnectionSuccess);
       await signingWallet();
       await setSelectedWallet(WALLET.WALLETCONNECT);
       await handleModalClose();

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -58,5 +58,5 @@ export const convertWalletConnectAccountName = (accountName) => {
     return '';
   }
   const nameSplits = accountName.split(':');
-  return `k:${nameSplits[nameSplits.length - 1]}`
+  return `k:${nameSplits[nameSplits.length - 1]}`;
 }

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -52,3 +52,11 @@ export const shortenAddress = (walletAddress, frontCount = 4, backCount = 4) => 
 
   return `${walletAddress.slice(0, 2 + frontCount)}...${walletAddress.slice(-backCount)}`;
 };
+
+export const convertWalletConnectAccountName = (accountName) => {
+  if (!accountName) {
+    return '';
+  }
+  const nameSplits = accountName.split(':');
+  return `k:${nameSplits[nameSplits.length - 1]}`
+}


### PR DESCRIPTION
Found issue on eckoSWAP. After your release of Wallet Connect V2 with KIP-17 (I did NOT participate in this release). As you remember, as for KIP-17, now accounts are named with public keys (NOT “k:publicKey”). But it seems eckoSWAP does not do correct fetching of account details.

For example, account balance fetching are done incorrectly on eckoSWAP after Wallet Connect success connection.

So I’m filing issue here with solution suggestion.

Solution would be create converter of account names from Wallet Connect V2 (KIP-17) to format that needed to chainweb node.